### PR TITLE
Lock typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",
-    "typescript": "^4.3.4"
+    "typescript": "4.3.4"
   }
 }


### PR DESCRIPTION
As typescript 4.3.4++ result error on compile, ["Object is of type 'unknown'.ts(2571)"](https://stackoverflow.com/questions/69422525/in-typescript-try-catch-error-object-shows-object-is-of-type-unknown-ts25/69422701) either fix code, or lock typescript at exact 4.3.4